### PR TITLE
Read relay chain state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3088,7 +3088,11 @@ dependencies = [
  "ismp",
  "ismp-parachain",
  "ismp-parachain-runtime-api",
+ "ismp-primitives",
+ "ismp-runtime-api",
+ "pallet-ismp",
  "parity-scale-codec",
+ "primitive-types",
  "sp-api",
  "sp-blockchain",
  "sp-inherents",
@@ -3099,6 +3103,7 @@ dependencies = [
 name = "ismp-parachain-runtime-api"
 version = "0.1.0"
 dependencies = [
+ "primitive-types",
  "sp-api",
 ]
 
@@ -3107,6 +3112,7 @@ name = "ismp-primitives"
 version = "0.1.0"
 dependencies = [
  "ckb-merkle-mountain-range",
+ "cumulus-primitives-core",
  "frame-system",
  "ismp",
  "parity-scale-codec",

--- a/pallet-ismp/primitives/Cargo.toml
+++ b/pallet-ismp/primitives/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Polytope Labs <hello@polytope.technology>"]
 # substrate
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", branch = "release-v0.9.420", default-features = false }
 
 # polytope labs
 ismp = { git = "https://github.com/polytope-labs/ismp-rs", branch = "main", default-features = false }
@@ -29,5 +30,6 @@ std = [
     "sp-runtime/std",
     "primitive-types/std",
     "scale-info/std",
+    "cumulus-primitives-core/std",
     "serde"
 ]

--- a/pallet-ismp/primitives/src/lib.rs
+++ b/pallet-ismp/primitives/src/lib.rs
@@ -19,6 +19,10 @@
 #![deny(missing_docs)]
 
 //! Primitives for the MMR implementation
+use cumulus_primitives_core::{
+    relay_chain,
+    relay_chain::{BlockNumber, Hash},
+};
 use ismp::host::StateMachine;
 
 pub mod mmr;
@@ -33,4 +37,23 @@ pub struct LeafIndexQuery {
     pub dest_chain: StateMachine,
     /// The request nonce
     pub nonce: u64,
+}
+
+/// Interface that exposes the relay chain state roots.
+pub trait RelayChainOracle {
+    /// Returns the state root for a given height if it exists.
+    fn state_root(height: relay_chain::BlockNumber) -> Option<relay_chain::Hash>;
+
+    /// Returns the highest known relay chain height
+    fn latest_relay_height() -> Option<u32>;
+}
+
+impl RelayChainOracle for () {
+    fn state_root(_height: BlockNumber) -> Option<Hash> {
+        None
+    }
+
+    fn latest_relay_height() -> Option<u32> {
+        None
+    }
 }

--- a/pallet-ismp/runtime-api/src/lib.rs
+++ b/pallet-ismp/runtime-api/src/lib.rs
@@ -20,6 +20,7 @@
 
 use ismp_rs::{
     consensus::{ConsensusClientId, StateMachineId},
+    host::StateMachine,
     router::{Get, Request, Response},
 };
 use pallet_ismp::primitives::{Error, Proof};
@@ -34,6 +35,9 @@ use sp_std::vec::Vec;
 sp_api::decl_runtime_apis! {
     /// ISMP Runtime Apis
     pub trait IsmpRuntimeApi<Hash: codec::Codec> {
+        /// Return the host state machine
+        fn host_state_machine() -> StateMachine;
+
         /// Return the number of MMR leaves.
         fn mmr_leaf_count() -> Result<LeafIndex, Error>;
 

--- a/pallet-ismp/src/lib.rs
+++ b/pallet-ismp/src/lib.rs
@@ -78,7 +78,10 @@ pub mod pallet {
     use alloc::collections::BTreeSet;
     use frame_support::{pallet_prelude::*, traits::UnixTime};
     use frame_system::pallet_prelude::*;
-    use ismp_primitives::mmr::{LeafIndex, NodeIndex};
+    use ismp_primitives::{
+        mmr::{LeafIndex, NodeIndex},
+        RelayChainOracle,
+    };
     use ismp_rs::{
         consensus::{ConsensusClientId, StateCommitment, StateMachineHeight, StateMachineId},
         handlers::{self},
@@ -122,6 +125,9 @@ pub mod pallet {
 
         /// Weight Info
         type WeightInfo: WeightInfo;
+
+        /// Optional Relay chain oracle.
+        type RelayChainOracle: RelayChainOracle;
 
         /// Weight provider for consensus clients and module callbacks
         type WeightProvider: WeightProvider;

--- a/pallet-ismp/src/mock.rs
+++ b/pallet-ismp/src/mock.rs
@@ -109,6 +109,7 @@ impl Config for Test {
     type TimeProvider = Timestamp;
     type IsmpRouter = ModuleRouter;
     type ConsensusClientProvider = ConsensusProvider;
+    type RelayChainOracle = ();
     type WeightInfo = ();
     type WeightProvider = ();
 }

--- a/parachain/inherent/Cargo.toml
+++ b/parachain/inherent/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Polytope Labs <hello@polytope.technology>"]
 async-trait = { version = "0.1.63" }
 codec = { package = "parity-scale-codec", version = "3.0.0", features = [ "derive" ] }
 anyhow = "1.0.57"
+primitive-types = "0.12.1"
 
 # Substrate
 sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }
@@ -23,3 +24,6 @@ cumulus-relay-chain-interface = {  git = "https://github.com/paritytech/cumulus"
 ismp = { git = "https://github.com/polytope-labs/ismp-rs", branch = "main" }
 ismp-parachain = { path = "../" }
 ismp-parachain-runtime-api = { path = "../runtime-api" }
+ismp-runtime-api = { path = "../../pallet-ismp/runtime-api" }
+ismp-primitives = { path = "../../pallet-ismp/primitives" }
+pallet-ismp = { path = "../../pallet-ismp" }

--- a/parachain/inherent/src/lib.rs
+++ b/parachain/inherent/src/lib.rs
@@ -19,17 +19,27 @@
 //! This exports the inherent provider for including ISMP parachain consensus updates as block
 //! inherents.
 
+use anyhow::anyhow;
 use codec::Encode;
 use cumulus_primitives_core::PersistedValidationData;
 use cumulus_relay_chain_interface::{PHash, RelayChainInterface};
-use ismp::messaging::ConsensusMessage;
-use ismp_parachain::consensus::{parachain_header_storage_key, ParachainConsensusProof};
+use ismp::{
+    consensus::{StateMachineHeight, StateMachineId},
+    host::StateMachine,
+    messaging::{ConsensusMessage, Message, Proof, ResponseMessage},
+    router::{Get, Request},
+};
+use ismp_parachain::consensus::{self, parachain_header_storage_key, ParachainConsensusProof};
 use ismp_parachain_runtime_api::IsmpParachainApi;
+use ismp_primitives::LeafIndexQuery;
+use ismp_runtime_api::IsmpRuntimeApi;
+use pallet_ismp::events::Event;
+use primitive_types::H256;
 use sp_runtime::traits::Block as BlockT;
 use std::sync::Arc;
 
 /// Implements [`InherentDataProvider`] for providing parachain consensus updates as inherents.
-pub struct ConsensusInherentProvider(Option<ConsensusMessage>);
+pub struct ConsensusInherentProvider(Option<Vec<Message>>);
 
 impl ConsensusInherentProvider {
     /// Create the [`ConsensusMessage`] at the given `relay_parent`. Will be [`None`] if no para ids
@@ -42,34 +52,105 @@ impl ConsensusInherentProvider {
     ) -> Result<ConsensusInherentProvider, anyhow::Error>
     where
         C: sp_api::ProvideRuntimeApi<B> + sp_blockchain::HeaderBackend<B>,
-        C::Api: IsmpParachainApi<B>,
+        C::Api: IsmpParachainApi<B> + IsmpRuntimeApi<B, H256>,
         B: BlockT,
     {
+        let mut messages = vec![];
         let head = client.info().best_hash;
         let para_ids = client.runtime_api().para_ids(head)?;
 
-        if para_ids.is_empty() {
+        if !para_ids.is_empty() {
+            let keys = para_ids.iter().map(|id| parachain_header_storage_key(*id).0).collect();
+            let storage_proof = relay_chain_interface
+                .prove_read(relay_parent, &keys)
+                .await?
+                .into_iter_nodes()
+                .collect();
+
+            let consensus_proof = ParachainConsensusProof {
+                para_ids,
+                relay_height: validation_data.relay_parent_number,
+                storage_proof,
+            };
+            let message = ConsensusMessage {
+                consensus_client_id: consensus::PARACHAIN_CONSENSUS_ID,
+                consensus_proof: consensus_proof.encode(),
+            };
+
+            messages.push(Message::Consensus(message));
+        }
+
+        // check the events in the last block
+
+        // relay chain state machine id is 0. todo: make it a constant
+        let relay_chain = match client.runtime_api().host_state_machine(head)? {
+            StateMachine::Polkadot(_) => StateMachine::Polkadot(0),
+            StateMachine::Kusama(_) => StateMachine::Kusama(0),
+            s => Err(anyhow!("Invalid host state machine, expected Polkadot/Kusama found {s:?}"))?,
+        };
+
+        let query = client
+            .runtime_api()
+            .block_events(head)?
+            .into_iter()
+            .filter_map(|event| match event {
+                Event::Request { dest_chain, source_chain, request_nonce: nonce }
+                    if dest_chain == relay_chain =>
+                {
+                    Some(LeafIndexQuery { source_chain, dest_chain, nonce })
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        let requests: Vec<Get> = client
+            .runtime_api()
+            .get_request_leaf_indices(head, query)
+            .and_then(|indices| client.runtime_api().get_requests(head, indices))?
+            .into_iter()
+            .filter_map(|req| match req {
+                Request::Get(get) => Some(get),
+                _ => None,
+            })
+            .collect();
+
+        // todo: batch requests with the same height
+
+        // for every request, read the keys in the relay chain storage.
+        for request in requests {
+            let root =
+                match client.runtime_api().relay_chain_state_root(head, request.height as u32)? {
+                    Some(root) => root,
+                    // ignore unkown heights, they'll timeout naturally.
+                    None => continue,
+                };
+
+            let proof = relay_chain_interface
+                .prove_read(root, &request.keys)
+                .await?
+                .into_iter_nodes()
+                .collect::<Vec<_>>();
+
+            messages.push(Message::Response(ResponseMessage::Get {
+                requests: vec![Request::Get(request.clone())],
+                proof: Proof {
+                    height: StateMachineHeight {
+                        id: StateMachineId {
+                            state_id: relay_chain,
+                            consensus_client: consensus::PARACHAIN_CONSENSUS_ID,
+                        },
+                        height: request.height,
+                    },
+                    proof: proof.encode(),
+                },
+            }));
+        }
+
+        if messages.is_empty() {
             return Ok(ConsensusInherentProvider(None))
         }
 
-        let keys = para_ids.iter().map(|id| parachain_header_storage_key(*id).0).collect();
-        let storage_proof = relay_chain_interface
-            .prove_read(relay_parent, &keys)
-            .await?
-            .into_iter_nodes()
-            .collect();
-
-        let consensus_proof = ParachainConsensusProof {
-            para_ids,
-            relay_height: validation_data.relay_parent_number,
-            storage_proof,
-        };
-        let message = ConsensusMessage {
-            consensus_client_id: ismp_parachain::consensus::PARACHAIN_CONSENSUS_ID,
-            consensus_proof: consensus_proof.encode(),
-        };
-
-        Ok(ConsensusInherentProvider(Some(message)))
+        Ok(ConsensusInherentProvider(Some(messages)))
     }
 }
 

--- a/parachain/inherent/src/lib.rs
+++ b/parachain/inherent/src/lib.rs
@@ -38,10 +38,10 @@ use primitive_types::H256;
 use sp_runtime::traits::Block as BlockT;
 use std::sync::Arc;
 
-/// Implements [`InherentDataProvider`] for providing parachain consensus updates as inherents.
-pub struct ConsensusInherentProvider(Option<Vec<Message>>);
+/// Implements [`InherentDataProvider`] for providing ISMP updates as inherents.
+pub struct IsmpInherentProvider(Option<Vec<Message>>);
 
-impl ConsensusInherentProvider {
+impl IsmpInherentProvider {
     /// Create the [`ConsensusMessage`] at the given `relay_parent`. Will be [`None`] if no para ids
     /// have been confguired.
     pub async fn create<C, B>(
@@ -49,7 +49,7 @@ impl ConsensusInherentProvider {
         relay_parent: PHash,
         relay_chain_interface: &impl RelayChainInterface,
         validation_data: PersistedValidationData,
-    ) -> Result<ConsensusInherentProvider, anyhow::Error>
+    ) -> Result<IsmpInherentProvider, anyhow::Error>
     where
         C: sp_api::ProvideRuntimeApi<B> + sp_blockchain::HeaderBackend<B>,
         C::Api: IsmpParachainApi<B> + IsmpRuntimeApi<B, H256>,
@@ -151,15 +151,15 @@ impl ConsensusInherentProvider {
         }
 
         if messages.is_empty() {
-            return Ok(ConsensusInherentProvider(None))
+            return Ok(IsmpInherentProvider(None))
         }
 
-        Ok(ConsensusInherentProvider(Some(messages)))
+        Ok(IsmpInherentProvider(Some(messages)))
     }
 }
 
 #[async_trait::async_trait]
-impl sp_inherents::InherentDataProvider for ConsensusInherentProvider {
+impl sp_inherents::InherentDataProvider for IsmpInherentProvider {
     async fn provide_inherent_data(
         &self,
         inherent_data: &mut sp_inherents::InherentData,

--- a/parachain/runtime-api/Cargo.toml
+++ b/parachain/runtime-api/Cargo.toml
@@ -9,7 +9,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }
+primitive-types = { version = "0.12.1", default-features = false }
 
 [features]
-default = ["std"]
+default = ["std", "primitive-types/std"]
 std = ["sp-api/std"]

--- a/parachain/runtime-api/src/lib.rs
+++ b/parachain/runtime-api/src/lib.rs
@@ -21,11 +21,15 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
+use primitive_types::H256;
 
 sp_api::decl_runtime_apis! {
     /// Ismp Parachain Runtime Apis
     pub trait IsmpParachainApi {
         /// Return all the para_ids this runtime is interested in. Used by the inherent provider
         fn para_ids() -> Vec<u32>;
+
+        /// Return a known relay chain storage root for a given height.
+        fn relay_chain_state_root(height: u32) -> Option<H256>;
     }
 }

--- a/parachain/src/consensus.rs
+++ b/parachain/src/consensus.rs
@@ -47,8 +47,8 @@ use crate::RelayChainOracle;
 /// The parachain consensus client implementation for ISMP.
 pub struct ParachainConsensusClient<T, R>(PhantomData<(T, R)>);
 
-/// The parachain state machine implementation for ISMP.
-pub struct ParachainStateMachine<T>(PhantomData<T>);
+/// The substrate state machine implementation for ISMP.
+pub struct SubstrateStateMachine<T>(PhantomData<T>);
 
 impl<T, R> Default for ParachainConsensusClient<T, R> {
     fn default() -> Self {
@@ -56,7 +56,7 @@ impl<T, R> Default for ParachainConsensusClient<T, R> {
     }
 }
 
-impl<T> Default for ParachainStateMachine<T> {
+impl<T> Default for SubstrateStateMachine<T> {
     fn default() -> Self {
         Self(PhantomData)
     }
@@ -248,11 +248,11 @@ where
     }
 
     fn state_machine(&self, _id: StateMachine) -> Result<Box<dyn StateMachineClient>, Error> {
-        Ok(Box::new(ParachainStateMachine::<T>::default()))
+        Ok(Box::new(SubstrateStateMachine::<T>::default()))
     }
 }
 
-impl<T> StateMachineClient for ParachainStateMachine<T>
+impl<T> StateMachineClient for SubstrateStateMachine<T>
 where
     T: pallet_ismp::Config + super::Config,
     T::BlockNumber: Into<u32>,

--- a/parachain/src/lib.rs
+++ b/parachain/src/lib.rs
@@ -130,13 +130,6 @@ pub mod pallet {
             if !RelayChainState::<T>::contains_key(state.number) {
                 RelayChainState::<T>::insert(state.number, state.state_root);
                 LatestRelayHeight::<T>::put(state.number);
-
-                let digest = sp_runtime::generic::DigestItem::Consensus(
-                    consensus::PARACHAIN_CONSENSUS_ID,
-                    state.number.encode(),
-                );
-
-                <frame_system::Pallet<T>>::deposit_log(digest);
             }
         }
 

--- a/parachain/src/lib.rs
+++ b/parachain/src/lib.rs
@@ -129,6 +129,7 @@ pub mod pallet {
             let state = RelaychainDataProvider::<T>::current_relay_chain_state();
             if !RelayChainState::<T>::contains_key(state.number) {
                 RelayChainState::<T>::insert(state.number, state.state_root);
+                LatestRelayHeight::<T>::put(state.number);
 
                 let digest = sp_runtime::generic::DigestItem::Consensus(
                     consensus::PARACHAIN_CONSENSUS_ID,

--- a/parachain/src/lib.rs
+++ b/parachain/src/lib.rs
@@ -97,10 +97,10 @@ pub mod pallet {
             Ok(Pays::No.into())
         }
 
-        /// Add some new parachains to the list of parachains we care about
+        /// Add some new parachains to the list of parachains whitelist
         #[pallet::call_index(1)]
         #[pallet::weight(0)]
-        pub fn add_parachain(origin: OriginFor<T>, para_ids: Vec<u32>) -> DispatchResult {
+        pub fn add_parachains(origin: OriginFor<T>, para_ids: Vec<u32>) -> DispatchResult {
             ensure_root(origin)?;
             for id in para_ids {
                 Parachains::<T>::insert(id, ());
@@ -109,10 +109,10 @@ pub mod pallet {
             Ok(())
         }
 
-        /// Remove some parachains from the list of parachains we care about
+        /// Remove some parachains from the list of parachains whitelist
         #[pallet::call_index(2)]
         #[pallet::weight(0)]
-        pub fn remove_parachain(origin: OriginFor<T>, para_ids: Vec<u32>) -> DispatchResult {
+        pub fn remove_parachains(origin: OriginFor<T>, para_ids: Vec<u32>) -> DispatchResult {
             ensure_root(origin)?;
             for id in para_ids {
                 Parachains::<T>::remove(id);


### PR DESCRIPTION
This refactors the `ConsensusInherentProvider` to a more general `IsmpInherentProvider`. This new inherent provider has been extended to support reading the relay chain state in order to respond to relay chain GET requests.

It might be possible to extend this further by fulfilling GET requests to sibling parachains, but it's unclear what the fee model for this inherent extrinsic would be for non-system requests.